### PR TITLE
Removed call to hook_update_N() from hook_install()

### DIFF
--- a/iqual.install
+++ b/iqual.install
@@ -19,7 +19,6 @@ use Drupal\Core\Field\Entity\BaseFieldOverride;
  */
 function iqual_install() {
   _set_iqual_base_settings();
-  iqual_update_8003();
   $author = Role::load('author');
   if ($author) {
     $author->grantPermission('restful get frontendpublishing_transitions');


### PR DESCRIPTION
This should not happen, calling `hook_update_N()` from `hook_install()`; it may block things as it is called before actual entity definitions are in place.