### PR TITLE
US-1337: Add update hook to install and configure drupal/disable_page_slash_node

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,8 @@
 {
   "name": "iqual/iqual_custom",
   "description": "A module for adding iqual additions.",
-  "type": "drupal-custom-module"
+  "type": "drupal-custom-module",
+  "require": {
+    "drupal/disable_page_slash_node": "^1.0"
+  }
 }

--- a/iqual.install
+++ b/iqual.install
@@ -218,3 +218,18 @@ function iqual_update_8004() {
     }
   }
 }
+
+/**
+ * Disable splash page using drupal/disable_page_slash_node.
+ */
+function iqual_update_9000() {
+  $moduleList = \Drupal::service('extension.list.module');
+  if ($moduleList->exists('disable_page_slash_node')) {
+    \Drupal::service('module_installer')->install(['disable_page_slash_node']);
+  }
+
+  \Drupal::configFactory()->getEditable('system.site')
+    ->set('site_disable_page_node', 0)
+    ->set('site_disable_page_node_404', 0)
+    ->save();
+}


### PR DESCRIPTION
This PR adds drupal/disable_page_slash_node as a dependency (composer only). On running update hooks, it will install and configure drupal/disable_page_slash_node to redirect /node to actual <front>.