### PR TITLE
process content-types to remove only if defined

### DIFF
--- a/iqual.module
+++ b/iqual.module
@@ -32,11 +32,10 @@ function iqual_preprocess_node_add_list(&$vars) {
   $config = \Drupal::config('iqual.settings');
   if ($config->get('hide_node_add_links')) {
     $contentTypesToRemmove = $config->get('hide_node_add_links');
-  }
-
-  foreach ($contentTypesToRemmove as $type) {
-    unset($vars['content'][$type]);
-    unset($vars['types'][$type]);
+    foreach ($contentTypesToRemmove as $type) {
+      unset($vars['content'][$type]);
+      unset($vars['types'][$type]);
+    }
   }
 }
 

--- a/iqual.module
+++ b/iqual.module
@@ -31,9 +31,9 @@ function iqual_preprocess_node_add_list(&$vars) {
 
   $config = \Drupal::config('iqual.settings');
   if ($config->get('hide_node_add_links')) {
-    $contentTypesToRemmove = $config->get('hide_node_add_links');
-    if (!empty($contentTypesToRemmove)) {
-      foreach ($contentTypesToRemmove as $type) {
+    $contentTypesToRemove = $config->get('hide_node_add_links');
+    if (!empty($contentTypesToRemove)) {
+      foreach ($contentTypesToRemove as $type) {
         unset($vars['content'][$type]);
         unset($vars['types'][$type]);
       }

--- a/iqual.module
+++ b/iqual.module
@@ -32,9 +32,11 @@ function iqual_preprocess_node_add_list(&$vars) {
   $config = \Drupal::config('iqual.settings');
   if ($config->get('hide_node_add_links')) {
     $contentTypesToRemmove = $config->get('hide_node_add_links');
-    foreach ($contentTypesToRemmove as $type) {
-      unset($vars['content'][$type]);
-      unset($vars['types'][$type]);
+    if (!empty($contentTypesToRemmove)) {
+      foreach ($contentTypesToRemmove as $type) {
+        unset($vars['content'][$type]);
+        unset($vars['types'][$type]);
+      }
     }
   }
 }


### PR DESCRIPTION
This PR prevents PHP Notice on add node page by ensuring the variable exists before processing it.