### PR TITLE
US-1706: Enable linkit on formats used in pagedesigner

### DIFF
--- a/iqual.install
+++ b/iqual.install
@@ -268,3 +268,27 @@ function iqual_update_9004(&$sandbox) {
     \Drupal::service('module_installer')->install(['exif_orientation']);
   }
 }
+
+/**
+ * Enable linkit on html editors used in pagedesigner.
+ */
+function iqual_update_9005(&$sandbox) {
+  /** @var \Drupal\Core\Extension\ModuleHandler $module_handler  */
+  $module_handler = \Drupal::service('module_handler');
+  if ($module_handler->moduleExists('pagedesigner') && $module_handler->moduleExists('linkit')) {
+
+    // Load html filter formats from pagedesigner.
+    $pagedesigner_settings = \Drupal::config('pagedesigner.settings');
+    $format_ids = array_unique([$pagedesigner_settings->get('filter_format'), $pagedesigner_settings->get('filter_format_textarea')]);
+    /** @var \Drupal\filter\Entity\FilterFormat[] $formats */
+    $formats = \Drupal::entityTypeManager()->getStorage('filter_format')->loadMultiple($format_ids);
+
+    // Enable linkit filter.
+    foreach ($formats as $format) {
+      $format->setFilterConfig('linkit',
+      ['status' => TRUE, 'weight' => 0, 'settings' => ['title' => TRUE]]
+      );
+      $format->save();
+    }
+  }
+}


### PR DESCRIPTION
Adds an update hook to enable linkit url conversion on filter formats used for html text in pagedesigner.