### PR TITLE
DUP-99: remove obsolete hook_node_access

### DIFF
--- a/iqual.module
+++ b/iqual.module
@@ -103,22 +103,3 @@ function iqual_get_locale_from_langcode($languageCode) {
   }
   return $languageLocaleCode;
 }
-
-/**
- * Implements hook_node_access().
- */
-function iqual_node_access(NodeInterface $node, $op, AccountInterface $account) {
-  if (!$account->isAnonymous()) {
-    return;
-  }
-  $langcode = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId();
-  if ($node->isTranslatable() && !$node->hasTranslation($langcode)) {
-    $access = AccessResult::forbidden();
-  }
-  else {
-    $access = AccessResult::neutral();
-  }
-  $access->addCacheableDependency($node);
-  $access->addCacheableDependency($account->getRoles());
-  return $access;
-}

--- a/iqual.module
+++ b/iqual.module
@@ -5,13 +5,9 @@
  * Contains iqual.module.
  */
 
-use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Language\LanguageInterface;
-use Drupal\Core\Session\AccountInterface;
 use Drupal\iqual\Form\LanguageEditForm;
 use Drupal\language\Entity\ConfigurableLanguage;
-use Drupal\node\NodeInterface;
 
 /**
  * Implements hook_form_alter().


### PR DESCRIPTION
## Issue

This module raise issues on some contexts due to a custom hook_node_access.

[iqual_custom/iqual.module at 7953bac51495dd5a06dd16276a9dfba9a67b4d64 · iqual-ch/iqual_custom](https://github.com/iqual-ch/iqual_custom/blob/7953bac51495dd5a06dd16276a9dfba9a67b4d64/iqual.module#L110) 

Example of context having issue:
Let us say we are in the german admin, we run xmlsitemap creation, then current language will be de. So for all content that do not have a german published version, access is false, and the content url won't be listed in the sitemap.

The other way around, if you are in italian, all node not having an italian translation won’t be accessible…

The hook was added on demand of the SEO team, cause unpublished translations returned 404 and they wanted 403.

But my test seem to show that drupal core indeed return 403 in this case.

## Fix
In first step 
- [x] Remove the hook and patch relevant projects

In a second step
- [x] Test the hook in a pagedesigner product branch and see if the core behaviour is indeed 403. 
- [x] If so, remove the hook during next update, if not, rework it to avoid issue raised.


