### PR TITLE
Use updated patch file and add drupal redirect to requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,12 +5,13 @@
   "require": {
     "php": "^8.1",
     "drupal/core": "^9.5 || ^10",
-    "drupal/exif_orientation": "^1.4"
+    "drupal/exif_orientation": "^1.4",
+    "drupal/redirect": "^1.12" 
   },
   "extra": {
     "patches": {
       "drupal/redirect": {
-        "#2904056: Keep path on domain redirect": "https://git.drupalcode.org/project/redirect/-/merge_requests/29.diff"
+        "[https://dgo.to/2904056]: Keep path on domain redirect": "https://www.drupal.org/files/issues/2025-09-24/2904056-38_keeping_path_on_domain_redirect.patch"
       }
     }
   }


### PR DESCRIPTION
This pull request updates the project dependencies and patches in the `composer.json` file. The most important changes are the addition of a new module dependency and an update to the patch reference for that module.

Dependency management:

* Added the `drupal/redirect` module as a required dependency with version `^1.12`.

Patch updates:

* Updated the patch reference for the `drupal/redirect` module to use a new URL and description format for the "Keep path on domain redirect" patch.