### PR TITLE
DUP-56: Add hook to disable frontpage view

### DIFF
--- a/iqual.install
+++ b/iqual.install
@@ -1022,3 +1022,16 @@ function iqual_update_10009() {
 
   return t('Media image field settings already up to date.');
 }
+
+/**
+ * Disable the 'frontpage' view.
+ */
+function iqual_update_10010() {
+  $view = \Drupal::configFactory()->getEditable('views.view.frontpage');
+  if (!$view->isNew()) {
+    $view->set('status', FALSE);
+    $view->save();
+    return t("Disabled the 'frontpage' view.");
+  }
+  return t("The 'frontpage' view was not found.");
+}


### PR DESCRIPTION
The `frontpage` view exposes the `/node` route which shows all nodes flagged with "Promote to frontpage". In our setup this usually applies to pagedesigner parts. 

This PR provides an update hook that disables the `frontpage` view and the `/node` route. 