### PR TITLE
DUP-312 RFI: exclude recycle bin from import by default

### DIFF
--- a/iqual.install
+++ b/iqual.install
@@ -1064,7 +1064,7 @@ function _iqual_rfi_supports_excluded_directories($dataSource): bool {
  * Add recycle-bin to the exclusion list of Remote File Importer data sources.
  */
 function iqual_update_10011() {
-  if (!\Drupal::moduleExists('remote_file_importer')) {
+  if (!\Drupal::moduleHandler()->moduleExists('remote_file_importer')) {
     return t('Remote File Importer is not installed, nothing to do.');
   }
 
@@ -1104,7 +1104,7 @@ function iqual_update_10011() {
  * Delete previously imported copies of excluded Remote File Importer folders.
  */
 function iqual_update_10012() {
-  if (!\Drupal::moduleExists('remote_file_importer')) {
+  if (!\Drupal::moduleHandler()->moduleExists('remote_file_importer')) {
     return t('Remote File Importer is not installed, nothing to do.');
   }
 

--- a/iqual.install
+++ b/iqual.install
@@ -1035,3 +1035,68 @@ function iqual_update_10010() {
   }
   return t("The 'frontpage' view was not found.");
 }
+
+/**
+ * Determines whether an RFI data source's plugin supports excluded folders.
+ *
+ * Directory exclusion is an opt-in plugin capability (see drupal.org issue
+ * #3591251); currently only the SFTP datasource plugin implements it. The
+ * method_exists() check keeps this safe on sites still running a module
+ * version without the exclusion feature.
+ *
+ * @param \Drupal\remote_file_importer\Entity\DataSource $dataSource
+ *   The data source config entity.
+ *
+ * @return bool
+ *   TRUE if the plugin supports directory exclusion, FALSE otherwise.
+ */
+function _iqual_rfi_supports_excluded_directories($dataSource): bool {
+  $pluginManager = \Drupal::service('plugin.manager.remote_file_importer.data_source');
+  $pluginId = $dataSource->get('plugin_id');
+  if (!$pluginId || !$pluginManager->hasDefinition($pluginId)) {
+    return FALSE;
+  }
+  $plugin = $pluginManager->createInstance($pluginId);
+  return method_exists($plugin, 'supportsExcludedDirectories') && $plugin->supportsExcludedDirectories();
+}
+
+/**
+ * Add recycle-bin to the exclusion list of Remote File Importer data sources.
+ */
+function iqual_update_10011() {
+  if (!\Drupal::moduleExists('remote_file_importer')) {
+    return t('Remote File Importer is not installed, nothing to do.');
+  }
+
+  $storage = \Drupal::entityTypeManager()->getStorage('rfi_data_source');
+  $updated = [];
+
+  foreach ($storage->loadMultiple() as $dataSource) {
+    if (!_iqual_rfi_supports_excluded_directories($dataSource)) {
+      continue;
+    }
+
+    // Add recycle-bin to the exclusion list, keeping existing entries.
+    $settings = $dataSource->get('settings') ?: [];
+    $existing = array_map('trim', explode(',', $settings['exclude_directories'] ?? ''));
+    $existing = array_values(array_filter($existing, static fn (string $item): bool => $item !== ''));
+    if (in_array('recycle-bin', array_map('strtolower', $existing), TRUE)) {
+      continue;
+    }
+
+    $existing[] = 'recycle-bin';
+    $settings['exclude_directories'] = implode(',', $existing);
+    $dataSource->set('settings', $settings);
+    $dataSource->save();
+    $updated[] = $dataSource->id();
+  }
+
+  if (!empty($updated)) {
+    return t('Added recycle-bin exclusion to data source(s): @ids. Remember to export config.', [
+      '@ids' => implode(', ', $updated),
+    ]);
+  }
+
+  return t('All data sources supporting exclusion already exclude recycle-bin.');
+}
+

--- a/iqual.install
+++ b/iqual.install
@@ -1100,3 +1100,76 @@ function iqual_update_10011() {
   return t('All data sources supporting exclusion already exclude recycle-bin.');
 }
 
+/**
+ * Delete previously imported copies of excluded Remote File Importer folders.
+ */
+function iqual_update_10012() {
+  if (!\Drupal::moduleExists('remote_file_importer')) {
+    return t('Remote File Importer is not installed, nothing to do.');
+  }
+
+  // /!\ WARNING: destructive operation. For every data source, this hook
+  // PERMANENTLY DELETES any local directory (at any depth inside the
+  // destination folder) whose name matches an entry of the data source's
+  // exclude_directories setting, as if it had never been imported. Imported
+  // files are unmanaged (no file entities), so deleting from disk is
+  // sufficient — but there is no undo. Review each data source's
+  // exclusion list before running this update.
+  $fileSystem = \Drupal::service('file_system');
+  $storage = \Drupal::entityTypeManager()->getStorage('rfi_data_source');
+  $deleted = [];
+
+  foreach ($storage->loadMultiple() as $dataSource) {
+    if (!_iqual_rfi_supports_excluded_directories($dataSource)) {
+      continue;
+    }
+
+    // Normalize the exclusion list the same way the module does.
+    $settings = $dataSource->get('settings') ?: [];
+    $excluded = array_map('trim', explode(',', $settings['exclude_directories'] ?? ''));
+    $excluded = array_map(static fn (string $item): string => trim(strtolower($item), '/'), $excluded);
+    $excluded = array_values(array_filter($excluded, static fn (string $item): bool => $item !== ''));
+    if (empty($excluded)) {
+      continue;
+    }
+
+    $destination = $dataSource->get('destination_base') . $dataSource->get('destination_folder');
+    $realpath = $fileSystem->realpath($destination);
+    if (!$realpath || !is_dir($realpath)) {
+      continue;
+    }
+
+    // Collect matching directories first, as deleting while iterating is
+    // not safe.
+    $targets = [];
+    $iterator = new \RecursiveIteratorIterator(
+      new \RecursiveDirectoryIterator($realpath, \FilesystemIterator::SKIP_DOTS),
+      \RecursiveIteratorIterator::SELF_FIRST
+    );
+    foreach ($iterator as $item) {
+      if ($item->isDir() && in_array(strtolower($item->getFilename()), $excluded, TRUE)) {
+        $targets[] = $item->getPathname();
+      }
+    }
+
+    foreach ($targets as $target) {
+      // Skip targets nested inside another target; deleting the parent
+      // already removes them.
+      foreach ($targets as $parent) {
+        if ($target !== $parent && str_starts_with($target, $parent . DIRECTORY_SEPARATOR)) {
+          continue 2;
+        }
+      }
+      $fileSystem->deleteRecursive($target);
+      $deleted[] = $dataSource->id() . ':' . substr($target, strlen($realpath));
+    }
+  }
+
+  if (!empty($deleted)) {
+    return t('Deleted local copies of excluded folder(s): @paths', [
+      '@paths' => implode(', ', $deleted),
+    ]);
+  }
+
+  return t('No local copies of excluded folders found.');
+}


### PR DESCRIPTION
Change spilt in 2 commits:
 1. Adds the `recycle-bin` folder to the exclusion list
 2. (Optional) Remove any existing folder stated in the exclusion list
 
 Requires these MR to be merged first:
 - https://git.drupalcode.org/project/remote_file_importer/-/merge_requests/23
 - https://git.drupalcode.org/project/remote_file_importer_sftp/-/merge_requests/8
 
 The hook updates check if the modules and config are available before proceeding (will work on builds without `remote_file_importer`)